### PR TITLE
fix: via.placeholder.com shut down in 2024 (now connection-refused)

### DIFF
--- a/data/blog/202312/Remove_Android_WebView_video_poster.mdx
+++ b/data/blog/202312/Remove_Android_WebView_video_poster.mdx
@@ -31,7 +31,7 @@ authors: ['default']
 // 透明 base64
 <video poster="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" />
 // or
-<video poster="https://via.placeholder.com/1x1" />
+<video poster="https://placehold.co/1x1" />
 // or
 <video poster="noposter" />
 ```


### PR DESCRIPTION
`data/blog/202312/Remove_Android_WebView_video_poster.mdx` references `via.placeholder.com/*`. The service was shut down in 2024 and the DNS record no longer resolves.

---

#### Why this is needed

`via.placeholder.com` was shut down in 2024 and its DNS record no longer resolves — every request now hangs or returns a connection error. Any example that references it renders a broken-image icon (and any code that depends on a 200 from it silently breaks).

Verify in any shell:

```
curl -sI --max-time 3 https://via.placeholder.com/300x200 || echo "connection refused / DNS gone"
```

#### What this PR changes

Fixes the `<video poster>` example URL in the 'Remove Android WebView video poster' blog post so the code block's example actually refers to a working 1×1 transparent placeholder.

#### Replacement details

1×1 placeholder preserved; `placehold.co/1x1` returns the same shape. The blog post's entire point is *replacing* a video poster with a 1×1 placeholder — a dead URL in this context makes the post's own demo broken.

#### Background

I'm tracking dead image-placeholder endpoints (`source.unsplash.com/*`, `via.placeholder.com/*`, `placekitten.com/*`) across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg is **not** a dependency of this PR — the diff uses the dependency-free canonical replacement (`placehold.co`, which accepts the same path shape as `via.placeholder.com`). If you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

One extra artifact you may find handy: a public scanner at <https://tteg.kushalsm.com/scan?url=> that highlights dead-placeholder patterns in any landing page — useful for verifying the fix lands and for finding other places dead URLs slipped in. Source: <https://github.com/kiluazen/tteg-landing/blob/main/scan.html>.
